### PR TITLE
Fix for missing property `mergedConfig`

### DIFF
--- a/Quartz2GrailsPlugin.groovy
+++ b/Quartz2GrailsPlugin.groovy
@@ -50,7 +50,7 @@ The goal is to keep it as simple as possible while making it friendly for Groovy
 
     def artefacts = [new JobArtefactHandler()]
 
-	def loadAfter = ['hibernate']
+	def loadAfter = ['hibernate', 'plugin-config']
 
     def doWithSpring = {
 		def mcfg = application.mergedConfig


### PR DESCRIPTION
Hi Josh,

Here's the fix for the issue i mentioned on the mailing list:

> When starting my app in dev mode, everything is fine.  When running
> from the WAR, I get the following Exception:

```
org.springframework.beans.factory.access.BootstrapException: Error executing bootstraps; nested exception is groovy.lang.MissingPropertyException: No such property: mergedConfig for class: org.codehaus.groovy.grails.commons.DefaultGrailsApplication
....
groovy.lang.MissingPropertyException: No such property: mergedConfig for class: org.codehaus.groovy.grails.commons.DefaultGrailsApplication
....
```

Alex
